### PR TITLE
Change MUST to SHOULD in BC for release process

### DIFF
--- a/release-process.rst
+++ b/release-process.rst
@@ -52,7 +52,7 @@ Minor Version Number
    -  Bugfixes
    -  New features
    -  Extensions support can be ended (moved to PECL)
-   -  Backward compatibility must be kept
+   -  Backward compatibility SHOULD be kept
    -  API compatibility must be kept (userland)
    -  ABI and API can be broken (internals)
    -  Source compatibility should be kept if possible, while breakages are


### PR DESCRIPTION
It's not respected anyways so it should be SHOULD, instead of MUST.