### PR TITLE
Clarify security classification for unsanitized args

### DIFF
--- a/security-classification.rst
+++ b/security-classification.rst
@@ -99,8 +99,8 @@ We do not classify as a security issue any issue that:
 -  requires invocation of specific code, which may be valid but is obviously
    malicious
 
--  requires invocation of functions with specific arguments, which may be valid
-   but are obviously malicious
+-  requires passing malicious arguments to functions clearly not intended to
+   receive unsanitized values, e.g. $query in mysqli_query()
 
 -  requires specific actions to be performed on the server, which are not
    commonly performed, or are not commonly permissible for the user (uid)

--- a/security-classification.rst
+++ b/security-classification.rst
@@ -100,7 +100,8 @@ We do not classify as a security issue any issue that:
    malicious
 
 -  requires passing malicious arguments to functions clearly not intended to
-   receive unsanitized values, e.g. $query in mysqli_query()
+   receive unsanitized values, e.g. mysqli_query(). escapeshellarg() on the
+   other hand should clearly be hardened against unsafe inputs.
 
 -  requires specific actions to be performed on the server, which are not
    commonly performed, or are not commonly permissible for the user (uid)


### PR DESCRIPTION
Clearly, some functions _should_ be hardened against malicious arguments. Clarify this only applies to some functions.