### PR TITLE
Fix and update links to BCP and RFCs in requirements terms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,10 @@ It contains the following items:
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in these
 documents are to be interpreted as described in `BCP 14
-<https://www.rfc-editor.org/bcp/bcp14.txt>`_ [`RFC2119
-<https://datatracker.ietf.org/doc/html/rfc2119>`_] [`RFC8174
-<https://datatracker.ietf.org/doc/html/rfc8174>`_] when, and only when, they
-appear in all capitals, as shown here.
+<https://www.rfc-editor.org/info/bcp14/>`_ [ `RFC2119
+<https://www.rfc-editor.org/info/rfc2119/>`_ ] [ `RFC8174
+<https://www.rfc-editor.org/info/rfc8174/>`_ ] when, and only when, they appear
+in all capitals, as shown here.
 
 ************
  Formatting


### PR DESCRIPTION
I noticed one of these links was dead and the other two point to the non-canonical URLs, so I've updated them to the correct canonical URLs.